### PR TITLE
Fix missing env variables when deploying the playground

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM node:10.15.1-alpine as aepp-playground-build
-ARG NODE_URL
-ARG NODE_INTERNAL_URL
 WORKDIR /app
 RUN apk add make gcc g++ python git
 COPY  . .
 RUN npm install
-RUN VUE_APP_NODE_URL=$NODE_URL VUE_APP_NODE_INTERNAL_URL=$NODE_INTERNAL_URL npm run build
+RUN npm run build
 
 FROM nginx:1.13.7-alpine
 

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ DOCKER_IMAGE = aepp-playground
 DOCKER_TAG = $(shell git describe --always --tags)
 # k8s
 K8S_NAMESPACE = testing
+VUE_APP_NODE_URL = https://sdk-testnet.aepps.com
+
 
 .PHONY: list
 list:
@@ -40,4 +42,4 @@ deploy-k8s:
 	@echo deploy k8s done
 
 debug-start:
-	VUE_APP_NODE_INTERNAL_URL='$(NODE_URL)' VUE_APP_NODE_URL='$(NODE_URL)' yarn start:dev
+	VUE_APP_NODE_INTERNAL_URL='$(VUE_APP_NODE_URL)' VUE_APP_NODE_URL='$(VUE_APP_NODE_URL)' yarn start:dev


### PR DESCRIPTION
This configurations now will take all of the env variables from the .env files and not from the docker build image.