### PR TITLE
Add verify transations

### DIFF
--- a/src/views/editor/index.vue
+++ b/src/views/editor/index.vue
@@ -335,7 +335,8 @@ export default {
           amount: 0,
           fee: null, // sdk will automatically select this
           gas: 1000000,
-          callData: ''
+          callData: '',
+          verify: true
         },
         callFnResult: {}
       }
@@ -490,7 +491,8 @@ export default {
           amount: 0,
           fee: null,
           gas: 1000000,
-          callData: ''
+          callData: '',
+          verify: true
         })
         Object.assign(this.callStaticFn, {
           functionName: null,


### PR DESCRIPTION
This option is added in order to avoid waiting for long transactions exceptions like "Giving after 10 mined blocks" and other issues which lead the application to hang.